### PR TITLE
Change default font from Times to Arial

### DIFF
--- a/www/template/css/style.css
+++ b/www/template/css/style.css
@@ -1,7 +1,7 @@
 body{
 	background-color: #f0f0f0;
 	margin:0px;
-	font-family: Times New Roman, arial, serif;
+	font-family: Arial, Helvetica, Sans-serif;
 }
 
 div#block {


### PR DESCRIPTION
Times doesn't fit all other fonts on the whole website. Serif fonts should normally be used for long texts intended for reading, not for any navigation elements.
